### PR TITLE
Refactor app into modular architecture

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,267 +1,216 @@
 "use client";
-import React, { useMemo, useState, useEffect } from "react";
-// NOTE: App.css not used in this sandbox; styles are inlined below.
 
-// ----------------------------- Types -----------------------------
-export type Matchup = { id: string; home: string; away: string; kickoff: string };
-export type Stick = { id: string; buyer: string; number: number; price: number; fee: number; createdAt: string };
-export type Group = { id: string; sticks: Stick[] };
-export type OrdersMap = Record<string, Group[]>;
-export type ResultsEntry = { homeScore: number; awayScore: number; digit: number } | null;
-export type ResultsMap = Record<string, ResultsEntry>;
-export type Config = { potPerStick: number };
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { AdminBar } from "../components/admin/AdminBar";
+import { Footer } from "../components/layout/Footer";
+import { Header } from "../components/layout/Header";
+import { Card } from "../components/layout/Card";
+import { AddMatchup } from "../components/matchups/AddMatchup";
+import { MatchupPicker } from "../components/matchups/MatchupPicker";
+import { BuyPanel } from "../components/orders/BuyPanel";
+import { GroupGrid } from "../components/orders/GroupGrid";
+import { ScoreSetter } from "../components/orders/ScoreSetter";
+import { useMatchups } from "../hooks/useMatchups";
+import { useOrders } from "../hooks/useOrders";
+import { load, save, STORAGE_KEYS } from "../lib/storage";
+import { Config, Matchup, OrdersMap, ResultsEntry, ResultsMap } from "../lib/types";
+import { calcTotalsForTest, clampInt, fmtDate, possibleWinnings, toMoney } from "../lib/game";
 
-// ----------------------------- Storage Helpers -----------------------------
-const uid = (): string => Math.random().toString(36).slice(2, 9);
-const save = <T,>(key: string, val: T): void => localStorage.setItem(key, JSON.stringify(val));
-const load = <T,>(key: string, fallback: T): T => {
-  try {
-    const v = localStorage.getItem(key);
-    return v ? (JSON.parse(v) as T) : fallback;
-  } catch {
-    return fallback;
-  }
-};
-
-const STORAGE_KEYS = {
-  matchups: 'ss_matchups',
-  activeId: 'ss_activeId',
-  config: 'ss_config_v2',
-  orders: 'ss_orders_v2',
-  results: 'ss_results_v2',
-  adminPin: 'ss_admin_pin_v1',
-  adminSession: 'ss_admin_session_v1',
-  view: 'ss_view_v1',
-} as const;
-
-const SAMPLE_MATCHUPS: Matchup[] = [
-  { id: uid(), home: "Bengals", away: "Steelers", kickoff: "2025-09-07T13:00:00" },
-  { id: uid(), home: "Chiefs", away: "Ravens", kickoff: "2025-09-07T16:25:00" },
-  { id: uid(), home: "49ers", away: "Cowboys", kickoff: "2025-09-08T20:20:00" },
-];
-
-// Config: pot per stick is fixed (label only for now)
 const defaultConfig: Config = {
   potPerStick: 10,
 };
 
-/** Data shape
- * ordersByMatchup: { [matchupId]: Array<Group> }
- * resultsByMatchup: { [matchupId]: ResultsEntry }
- */
-
 export default function App() {
-  const [matchups, setMatchups] = useState<Matchup[]>(() => load(STORAGE_KEYS.matchups, SAMPLE_MATCHUPS));
-  const [activeId, setActiveId] = useState<string | null>(() => load(STORAGE_KEYS.activeId, (matchups[0]?.id ?? null)));
+  const { matchups, activeId, view, activeMatchup, setActiveId, setView, addMatchup, removeMatchup, hydrate: hydrateMatchups, reset: resetMatchups } = useMatchups();
+  const { orders, results, groupsForMatchup, totalsForMatchup, buySticks, setScores, clearScores, clearMatchupData, hydrate: hydrateOrders, reset: resetOrders, winDigitForMatchup } = useOrders();
+
   const [config, setConfig] = useState<Config>(() => load(STORAGE_KEYS.config, defaultConfig));
-  const [orders, setOrders] = useState<OrdersMap>(() => load(STORAGE_KEYS.orders, {})); // groups per matchup
-  const [results, setResults] = useState<ResultsMap>(() => load(STORAGE_KEYS.results, {})); // scores per matchup
-
-  // Admin: PIN (optional) + session flag
   const [adminPin, setAdminPin] = useState<string | null>(() => load(STORAGE_KEYS.adminPin, null));
-  const [isAdmin, setIsAdmin] = useState<boolean>(() => !!load(STORAGE_KEYS.adminSession, false)); 
+  const [isAdmin, setIsAdmin] = useState<boolean>(() => !!load(STORAGE_KEYS.adminSession, false));
 
-  // Simple view routing: 'home' (only matchups) or 'game' (detail page)
-  const [view, setView] = useState<'home' | 'game'>(() => load(STORAGE_KEYS.view, 'home'));
-
-  useEffect(() => save(STORAGE_KEYS.matchups, matchups), [matchups]);
-  useEffect(() => save(STORAGE_KEYS.activeId, activeId), [activeId]);
   useEffect(() => save(STORAGE_KEYS.config, config), [config]);
-  useEffect(() => save(STORAGE_KEYS.orders, orders), [orders]);
-  useEffect(() => save(STORAGE_KEYS.results, results), [results]);
   useEffect(() => save(STORAGE_KEYS.adminPin, adminPin), [adminPin]);
   useEffect(() => save(STORAGE_KEYS.adminSession, isAdmin), [isAdmin]);
-  useEffect(() => save(STORAGE_KEYS.view, view), [view]);
 
-  // Quick runtime sanity checks ("tests") for utilities
+  const activeGroups = useMemo(() => groupsForMatchup(activeId), [groupsForMatchup, activeId]);
+  const totals = useMemo(() => totalsForMatchup(activeId), [totalsForMatchup, activeId]);
+  const winDigit = useMemo(() => winDigitForMatchup(activeId), [winDigitForMatchup, activeId]);
+
   useEffect(() => {
     try {
-      console.assert(clampInt("5", 1, 10) === 5, 'clampInt basic');
-      console.assert(clampInt(99, 1, 10) === 10, 'clampInt upper bound');
-      console.assert(clampInt(-3, 0, 5) === 0, 'clampInt lower bound');
-      console.assert(toMoney('1.239') === 1.24 && toMoney(-5) === 0, 'toMoney rounding + non-negative');
-      console.assert(possibleWinnings(0) === 0 && possibleWinnings(3) === 300, 'possibleWinnings basic');
+      console.assert(clampInt("5", 1, 10) === 5, "clampInt basic");
+      console.assert(clampInt(99, 1, 10) === 10, "clampInt upper bound");
+      console.assert(clampInt(-3, 0, 5) === 0, "clampInt lower bound");
+      console.assert(toMoney("1.239") === 1.24 && toMoney(-5) === 0, "toMoney rounding + non-negative");
+      console.assert(possibleWinnings(0) === 0 && possibleWinnings(3) === 300, "possibleWinnings basic");
       const t = calcTotalsForTest({ groups: 3, sticks: 27, pot: 10 });
-      console.assert(t.groups === 3 && t.totalCharged === 270 && t.possibleW === 300, 'calcTotalsForTest sanity');
+      console.assert(t.groups === 3 && t.totalCharged === 270 && t.possibleW === 300, "calcTotalsForTest sanity");
       const t2 = calcTotalsForTest({ groups: 1, prices: [10, 10] });
-      console.assert(t2.groups === 1 && t2.totalCharged === 20 && t2.possibleW === 100, 'calcTotalsForTest prices array (2×$10)');
+      console.assert(t2.groups === 1 && t2.totalCharged === 20 && t2.possibleW === 100, "calcTotalsForTest prices array (2×$10)");
       const t3 = calcTotalsForTest({ groups: 2, prices: [10, 12] });
-      console.assert(t3.groups === 2 && t3.totalCharged === 22 && t3.possibleW === 200, 'calcTotalsForTest prices array (mixed)');
+      console.assert(t3.groups === 2 && t3.totalCharged === 22 && t3.possibleW === 200, "calcTotalsForTest prices array (mixed)");
       const t4 = calcTotalsForTest({ groups: 0, prices: [] });
-      console.assert(t4.groups === 0 && t4.totalCharged === 0 && t4.possibleW === 0, 'calcTotalsForTest empty');
-      const d = fmtDate('2025-01-01T00:00:00Z');
-      console.assert(typeof d === 'string' && d.length > 0, 'fmtDate returns string');
-    } catch (e) { /* ignore in prod */ }
+      console.assert(t4.groups === 0 && t4.totalCharged === 0 && t4.possibleW === 0, "calcTotalsForTest empty");
+      const d = fmtDate("2025-01-01T00:00:00Z");
+      console.assert(typeof d === "string" && d.length > 0, "fmtDate returns string");
+    } catch {
+      // ignore in production
+    }
   }, []);
 
-  const active = useMemo<Matchup | null>(() => matchups.find(m => m.id === activeId) ?? null, [matchups, activeId]);
-  const activeGroups = useMemo<Group[]>(() => (activeId ? (orders[activeId] ?? []) : []), [orders, activeId]);
+  const handleSelectMatchup = useCallback((id: string) => {
+    setActiveId(id);
+    setView("game");
+  }, [setActiveId, setView]);
 
-  // -------------------------- Matchups --------------------------
-  const addMatchup = (home: string, away: string, kickoff: string) => {
-    if (!isAdmin) { alert('Admins only.'); return; }
-    const m: Matchup = { id: uid(), home, away, kickoff };
-    setMatchups(v => [m, ...v]);
-    setActiveId(m.id);
-    setView('game');
-  };
+  const handleAddMatchup = useCallback((home: string, away: string, kickoff: string) => {
+    if (!isAdmin) {
+      alert("Admins only.");
+      return;
+    }
+    addMatchup({ home, away, kickoff });
+  }, [addMatchup, isAdmin]);
 
-  const removeMatchup = (id: string) => {
-    if (!isAdmin) { alert('Admins only.'); return; }
-    setMatchups(prev => {
-      const next = prev.filter(m => m.id !== id);
-      setActiveId(a => (a === id ? (next[0]?.id ?? null) : a));
-      if (id === activeId) setView('home');
-      return next;
-    });
-    setOrders(prev => { const c = { ...prev }; delete c[id]; return c; });
-    setResults(prev => { const c = { ...prev }; delete c[id]; return c; });
-  };
+  const handleRemoveMatchup = useCallback((id: string) => {
+    if (!isAdmin) {
+      alert("Admins only.");
+      return;
+    }
+    removeMatchup(id);
+    clearMatchupData(id);
+  }, [clearMatchupData, isAdmin, removeMatchup]);
 
-  // ---------------------- Buying sticks ----------------------
-  // Assign numbers 0–9 unique within the current group.
-  const buySticks = (buyerName: string, quantity: number) => {
-    if (!active) return;
-    const q = clampInt(quantity, 1, 10); // cap at 10
-    const buyer = (buyerName && buyerName.trim()) || "Guest";
+  const handleBuy = useCallback((buyer: string, quantity: number) => {
+    if (!activeMatchup) return;
+    buySticks({ matchupId: activeMatchup.id, buyer, quantity, pricePerStick: config.potPerStick });
+  }, [activeMatchup, buySticks, config.potPerStick]);
 
-    setOrders(prev => {
-      const matchId = active.id;
-      const groups: Group[] = [...(prev[matchId] ?? [])];
-      const nowIso = new Date().toISOString();
+  const handleSetScores = useCallback((homeScore: number, awayScore: number) => {
+    if (!activeMatchup) return;
+    if (!isAdmin) {
+      alert("Admins only.");
+      return;
+    }
+    setScores(activeMatchup.id, homeScore, awayScore);
+  }, [activeMatchup, isAdmin, setScores]);
 
-      let remaining = q;
-      while (remaining > 0) {
-        if (groups.length === 0 || groups[groups.length - 1].sticks.length >= 10) {
-          groups.push({ id: uid(), sticks: [] });
-        }
-        const g = groups[groups.length - 1];
-        const takenNums = new Set(g.sticks.map(s => s.number));
-        const available = Array.from({ length: 10 }, (_, i) => i).filter(n => !takenNums.has(n));
-        if (available.length === 0) continue; // defensive
+  const handleClearScores = useCallback(() => {
+    if (!activeMatchup) return;
+    if (!isAdmin) {
+      alert("Admins only.");
+      return;
+    }
+    clearScores(activeMatchup.id);
+  }, [activeMatchup, clearScores, isAdmin]);
 
-        const toPlace = Math.min(available.length, remaining);
-        for (let i = 0; i < toPlace; i++) {
-          const nIdx = Math.floor(Math.random() * available.length);
-          const num = available.splice(nIdx, 1)[0];
-          g.sticks.push({
-            id: uid(),
-            buyer,
-            number: num,
-            price: asMoney(config.potPerStick), // stored as number
-            fee: 0, // platform fee disabled for now
-            createdAt: nowIso,
-          });
-          remaining--;
-        }
-      }
-      return { ...prev, [matchId]: groups } as OrdersMap;
-    });
-  };
-
-  // ------------------------- Results -------------------------
-  const setScores = (homeScore: number, awayScore: number) => {
-    if (!active) return;
-    const hs = clampInt(homeScore, 0, Number.MAX_SAFE_INTEGER);
-    const as = clampInt(awayScore, 0, Number.MAX_SAFE_INTEGER);
-    const digit = (hs + as) % 10;
-    setResults(prev => ({ ...prev, [active.id]: { homeScore: hs, awayScore: as, digit } }));
-  };
-
-  const clearScores = () => {
-    if (!active) return;
-    setResults(prev => ({ ...prev, [active.id]: null }));
-  };
-
-  // -------------------------- Totals --------------------------
-  const totals = useMemo(() => {
-    const sticks = activeGroups.reduce((s, g) => s + g.sticks.length, 0);
-    const groups = activeGroups.length;
-    const totalCharged = activeGroups.reduce(
-      (sum, g) => sum + g.sticks.reduce((inner, st) => inner + toNumber(st.price), 0),
-      0
-    );
-    const possibleW = possibleWinnings(groups);
-    return { sticks, groups, totalCharged, possibleW } as const;
-  }, [activeGroups]);
-
-  const winDigit = active ? (results[active.id]?.digit ?? null) : null;
-
-  // --------------------- Backup / Restore ---------------------
-  const exportJson = () => {
+  const exportJson = useCallback(() => {
     const payload = {
       version: 1,
       exportedAt: new Date().toISOString(),
       data: {
         matchups,
         activeId,
+        view,
         config,
         orders,
         results,
         adminPin: !!adminPin,
       },
     };
-    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
+    const a = document.createElement("a");
     a.href = url;
     a.download = `sports-sticks-backup-${Date.now()}.json`;
     a.click();
     URL.revokeObjectURL(url);
-  };
+  }, [activeId, adminPin, config, matchups, orders, results, view]);
 
-  const importJson = async (file?: File) => {
+  const importJson = useCallback(async (file?: File) => {
     if (!file) return;
     try {
       const text = await file.text();
-      const parsed = JSON.parse(text) as any;
-      const d = parsed?.data ?? parsed; // accept either wrapper or raw
-      if (!d) throw new Error('Invalid file');
-      setMatchups(Array.isArray(d.matchups) ? (d.matchups as Matchup[]) : []);
-      setActiveId((d.activeId as string | null) ?? null);
-      setConfig((d.config as Config) ?? defaultConfig);
-      setOrders((d.orders as OrdersMap) ?? {});
-      setResults((d.results as ResultsMap) ?? {});
-    } catch (e: any) {
-      alert('Import failed: ' + (e?.message || 'Unknown error'));
+      const parsed = JSON.parse(text) as unknown;
+      const root = typeof parsed === "object" && parsed !== null ? parsed : {};
+      const maybeData = (root as { data?: unknown }).data ?? root;
+      if (typeof maybeData !== "object" || maybeData === null) {
+        throw new Error("Invalid file");
+      }
+      const data = maybeData as Record<string, unknown>;
+      const nextMatchups = Array.isArray(data.matchups) ? (data.matchups as Matchup[]) : [];
+      const rawActive = data.activeId;
+      const nextActiveId = typeof rawActive === "string" || rawActive === null ? (rawActive as string | null) : null;
+      const nextView = data.view === "game" ? "game" : "home";
+      hydrateMatchups({
+        matchups: nextMatchups,
+        activeId: nextActiveId,
+        view: nextView,
+      });
+      const nextOrders =
+        data.orders && typeof data.orders === "object" && data.orders !== null ? (data.orders as OrdersMap) : {};
+      const nextResults =
+        data.results && typeof data.results === "object" && data.results !== null ? (data.results as ResultsMap) : {};
+      hydrateOrders({
+        orders: nextOrders,
+        results: nextResults,
+      });
+      const configSource = data.config;
+      const nextConfig: Config =
+        typeof configSource === "object" && configSource !== null
+          ? { potPerStick: Number((configSource as { potPerStick?: unknown }).potPerStick) || defaultConfig.potPerStick }
+          : defaultConfig;
+      setConfig(nextConfig);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      alert("Import failed: " + message);
     }
-  };
+  }, [hydrateMatchups, hydrateOrders]);
 
-  const resetAll = () => {
-    if (!confirm('Reset ALL local game data? This cannot be undone.')) return;
-    for (const k of Object.values(STORAGE_KEYS)) localStorage.removeItem(k);
-    setMatchups(SAMPLE_MATCHUPS);
-    setActiveId(SAMPLE_MATCHUPS[0].id);
+  const resetAll = useCallback(() => {
+    if (!confirm("Reset ALL local game data? This cannot be undone.")) return;
+    if (typeof window !== "undefined") {
+      Object.values(STORAGE_KEYS).forEach((key) => localStorage.removeItem(key));
+    }
+    resetMatchups();
+    resetOrders();
     setConfig(defaultConfig);
-    setOrders({});
-    setResults({});
     setAdminPin(null);
     setIsAdmin(false);
-    setView('home');
-  };
+    setView("home");
+  }, [resetMatchups, resetOrders, setView]);
 
-  // Admin login helpers
-  const handleSetPin = (pin: string) => {
-    if (!pin || pin.length < 4) { alert('Choose a 4+ digit PIN.'); return; }
+  const handleSetPin = useCallback((pin: string) => {
+    if (!pin || pin.length < 4) {
+      alert("Choose a 4+ digit PIN.");
+      return;
+    }
     setAdminPin(String(pin));
     setIsAdmin(true);
-  };
-  const handleLogin = (pin: string) => {
-    if (String(pin) === String(adminPin)) { setIsAdmin(true); }
-    else alert('Wrong PIN');
-  };
-  const handleLogout = () => setIsAdmin(false);
-  const handleClearPin = () => {
-    if (!confirm('Remove the Admin PIN?')) return; setAdminPin(null); setIsAdmin(false);
-  };
+  }, []);
 
-  // ------------------------------ Render ------------------------------
+  const handleLogin = useCallback((pin: string) => {
+    if (String(pin) === String(adminPin)) {
+      setIsAdmin(true);
+    } else {
+      alert("Wrong PIN");
+    }
+  }, [adminPin]);
+
+  const handleLogout = useCallback(() => setIsAdmin(false), []);
+
+  const handleClearPin = useCallback(() => {
+    if (!confirm("Remove the Admin PIN?")) return;
+    setAdminPin(null);
+    setIsAdmin(false);
+  }, []);
+
+  const activeResult: ResultsEntry = activeMatchup ? results[activeMatchup.id] ?? null : null;
+
   return (
     <div className="min-h-screen bg-slate-50 text-slate-900">
       <div className="max-w-6xl mx-auto p-4 md:p-8">
         <Header />
 
-        {/* Admin Bar */}
         <AdminBar
           adminPin={adminPin}
           isAdmin={isAdmin}
@@ -271,78 +220,73 @@ export default function App() {
           onClearPin={handleClearPin}
         />
 
-        {/* App Controls */}
         <div className="flex flex-wrap gap-2 mt-4">
           <button className="btn" onClick={exportJson}>Export JSON</button>
           <label className="btn-ghost cursor-pointer">
             Import JSON
-            <input type="file" accept="application/json" style={{ display: 'none' }}
-                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => importJson(e.target.files?.[0])} />
+            <input
+              type="file"
+              accept="application/json"
+              style={{ display: "none" }}
+              onChange={(event) => importJson(event.target.files?.[0])}
+            />
           </label>
           <button className="btn-ghost" onClick={resetAll}>Reset Data</button>
         </div>
 
-        {/* ROUTES */}
-        {view === 'home' ? (
+        {view === "home" ? (
           <div className="grid lg:grid-cols-3 gap-6 mt-6">
-            {/* Left: Matchup Manager only */}
             <Card title="Matchups">
               <MatchupPicker
                 matchups={matchups}
                 activeId={activeId}
-                setActiveId={(id: string) => { setActiveId(id); setView('game'); }}
-                onRemove={isAdmin ? removeMatchup : undefined}
+                onSelect={handleSelectMatchup}
+                onRemove={isAdmin ? handleRemoveMatchup : undefined}
               />
               {isAdmin ? (
-                <AddMatchup onAdd={addMatchup} />
+                <AddMatchup onAdd={handleAddMatchup} />
               ) : (
                 <div className="rounded-xl border p-3 bg-white text-sm opacity-70">Admin required to add a matchup.</div>
               )}
             </Card>
           </div>
         ) : (
-          // GAME VIEW
           <div className="mt-6 space-y-4">
             <div className="flex items-center justify-between">
-              <button className="btn-ghost" onClick={() => setView('home')}>← Back to Matchups</button>
-              {active ? (
-                <div className="pill">{active.home} vs {active.away}</div>
+              <button className="btn-ghost" onClick={() => setView("home")}>← Back to Matchups</button>
+              {activeMatchup ? (
+                <div className="pill">{activeMatchup.home} vs {activeMatchup.away}</div>
               ) : <span />}
             </div>
 
             <div className="grid lg:grid-cols-2 gap-6">
-              {/* Game & Sticks */}
               <Card title="Game & Sticks">
-                {active ? (
+                {activeMatchup ? (
                   <div className="space-y-4">
                     <div className="rounded-xl border p-3 bg-white">
-                      <div className="font-semibold text-lg">{active.home} vs {active.away}</div>
-                      <div className="text-sm opacity-70">Kickoff: {fmtDate(active.kickoff)}</div>
+                      <div className="font-semibold text-lg">{activeMatchup.home} vs {activeMatchup.away}</div>
+                      <div className="text-sm opacity-70">Kickoff: {fmtDate(activeMatchup.kickoff)}</div>
                     </div>
 
-                    {/* Pot per stick: label only */}
                     <div className="rounded-xl border p-3 bg-white space-y-3">
                       <div className="flex items-center justify-between gap-3">
                         <span className="text-sm">Pot per stick</span>
-                        <span className="text-sm font-semibold">${toNumber(config.potPerStick).toFixed(2)}</span>
+                        <span className="text-sm font-semibold">${Number(config.potPerStick).toFixed(2)}</span>
                       </div>
                     </div>
 
-                    {/* Buy flow */}
-                    <BuyPanel onBuy={buySticks} />
+                    <BuyPanel onBuy={handleBuy} />
 
-                    {/* Scores */}
                     <div className="rounded-xl border p-3 bg-white space-y-2">
                       <div className="font-semibold">Final Score → Winning Digit</div>
                       {isAdmin ? (
-                        <ScoreSetter active={active} results={results} onSet={setScores} onClear={clearScores} />
+                        <ScoreSetter matchup={activeMatchup} result={activeResult} onSet={handleSetScores} onClear={handleClearScores} />
                       ) : (
                         <div className="text-sm opacity-70">Admin required to set scores.</div>
                       )}
                       <div className="text-sm opacity-70">Winning digit: <b>{winDigit ?? "—"}</b></div>
                     </div>
 
-                    {/* Totals */}
                     <div className="rounded-xl border p-3 bg-white">
                       <div className="font-semibold mb-2">Totals</div>
                       <ul className="text-sm space-y-1">
@@ -357,20 +301,19 @@ export default function App() {
                 )}
               </Card>
 
-              {/* Groups & Results */}
               <Card title="Groups (0–9) & Results">
-                {active ? (
+                {activeMatchup ? (
                   <div className="space-y-4">
                     {activeGroups.length === 0 ? (
                       <div className="text-sm opacity-70">No sticks yet. Sell some!</div>
                     ) : (
-                      activeGroups.map((g, idx) => (
-                        <div key={g.id} className="rounded-xl border p-3 bg-white">
+                      activeGroups.map((group, index) => (
+                        <div key={group.id} className="rounded-xl border p-3 bg-white">
                           <div className="flex items-center justify-between mb-2">
-                            <div className="font-semibold">Group #{idx + 1}</div>
-                            <div className="text-xs opacity-70">{g.sticks.length}/10 filled</div>
+                            <div className="font-semibold">Group #{index + 1}</div>
+                            <div className="text-xs opacity-70">{group.sticks.length}/10 filled</div>
                           </div>
-                          <GroupGrid sticks={g.sticks} winDigit={winDigit} />
+                          <GroupGrid sticks={group.sticks} winDigit={winDigit} />
                         </div>
                       ))
                     )}
@@ -386,7 +329,6 @@ export default function App() {
         <Footer />
       </div>
 
-      {/* Styles */}
       <style>{`
         .btn { padding: 0.5rem 0.75rem; border-radius: 1rem; background:#0f172a; color:#fff; font-size:0.9rem; box-shadow:0 2px 6px rgba(0,0,0,.12); border: none; cursor:pointer }
         .btn:hover { opacity:.95 }
@@ -406,242 +348,4 @@ export default function App() {
       `}</style>
     </div>
   );
-}
-
-function Header() {
-  return (
-    <div className="flex flex-col md:flex-row items-start md:items-center gap-3 md:gap-6">
-      <div>
-        <h1 className="text-2xl md:text-3xl font-bold">Sports Sticks – Mini MVP</h1>
-        <p className="muted">Each group holds numbers 0–9. (home+away) % 10 decides the winner.</p>
-      </div>
-    </div>
-  );
-}
-
-type AdminBarProps = {
-  adminPin: string | null;
-  isAdmin: boolean;
-  onSetPin: (pin: string) => void;
-  onLogin: (pin: string) => void;
-  onLogout: () => void;
-  onClearPin: () => void;
-};
-
-function AdminBar({ adminPin, isAdmin, onSetPin, onLogin, onLogout, onClearPin }: AdminBarProps) {
-  const [pinInput, setPinInput] = useState("");
-  const [newPin, setNewPin] = useState("");
-
-  return (
-    <div className="mt-3 rounded-xl border p-3 bg-white flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-      <div className="font-semibold">Admin</div>
-      {adminPin ? (
-        <div className="flex gap-2 items-center flex-wrap">
-          <span className="text-sm">Status: <b>{isAdmin ? 'Logged in' : 'Logged out'}</b></span>
-          {isAdmin ? (
-            <>
-              <button className="btn-ghost" onClick={onLogout}>Logout</button>
-              <button className="btn-ghost" onClick={onClearPin}>Remove PIN</button>
-            </>
-          ) : (
-            <>
-              <input className="input input-sm" placeholder="Enter PIN" value={pinInput}
-                     onChange={e => setPinInput(e.target.value.replace(/[^0-9]/g, ''))} />
-              <button className="btn" onClick={() => { onLogin(pinInput); setPinInput(""); }}>Login</button>
-            </>
-          )}
-        </div>
-      ) : (
-        <div className="flex gap-2 items-center flex-wrap">
-          <input className="input input-sm" placeholder="Set new PIN (4+ digits)" value={newPin}
-                 onChange={e => setNewPin(e.target.value.replace(/[^0-9]/g, ''))} />
-          <button className="btn" onClick={() => { onSetPin(newPin); setNewPin(""); }}>Set PIN</button>
-          <span className="text-xs opacity-70">(This PIN stays only on this device)</span>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function Footer() {
-  return (
-    <div className="mt-8 text-center text-xs text-slate-500">
-      Built fast. Iterate later with auth, payments, live NFL feeds.
-    </div>
-  );
-}
-
-function Card({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <div className="card">
-      <h3 className="font-semibold">{title}</h3>
-      {children}
-    </div>
-  );
-}
-
-function MatchupPicker({ matchups, activeId, setActiveId, onRemove }: {
-  matchups: Matchup[];
-  activeId: string | null;
-  setActiveId: (id: string) => void;
-  onRemove?: (id: string) => void;
-}) {
-  return (
-    <div className="rounded-xl border p-2 bg-white mb-3 max-h-[240px] overflow-auto">
-      {matchups.length === 0 ? (
-        <div className="text-sm opacity-70 p-2">No matchups yet.</div>
-      ) : (
-        <ul className="space-y-1">
-          {matchups.map((m) => (
-            <li key={m.id} className="flex items-center justify-between gap-2 p-2 rounded-lg hover:bg-slate-50">
-              <button onClick={() => setActiveId(m.id)}
-                className={"kckStyle text-sm text-left flex-1 " + (activeId === m.id ? "font-semibold" : "")}
-                title={m.kickoff}>
-                {m.home} vs {m.away}
-                <span className="block text-[11px] opacity-60">{fmtDate(m.kickoff)}</span>
-              </button>
-              {onRemove ? (
-                <button className="kckStyle pill pill-ghost" onClick={() => onRemove(m.id)}>Remove</button>
-              ) : (
-                <span className="text-[11px] opacity-50">Admin only</span>
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  );
-}
-
-function AddMatchup({ onAdd }: { onAdd: (home: string, away: string, kickoff: string) => void }) {
-  const [home, setHome] = useState("");
-  const [away, setAway] = useState("");
-  const [kickoff, setKickoff] = useState("");
-
-  return (
-    <div className="rounded-xl border p-3 bg-white space-y-2">
-      <div className="kckStyle2 text-sm font-medium">Add a matchup</div>
-      <div className="grid grid-cols-2 gap-2">
-        <input className="kckStyle input text-left" placeholder="Home" value={home} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setHome(e.target.value)} />
-        <input className="kckStyle input text-left" placeholder="Away" value={away} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAway(e.target.value)} />
-      </div>
-      <input className="input input-wide text-left" type="datetime-local" value={kickoff} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setKickoff(e.target.value)} />
-      <button className="btn w-full" onClick={() => {
-        if (!home || !away) { alert("Enter home & away team names"); return; }
-        onAdd(home.trim(), away.trim(), kickoff || new Date().toISOString());
-        setHome(""); setAway(""); setKickoff("");
-      }}>Add</button>
-    </div>
-  );
-}
-
-function BuyPanel({ onBuy }: { onBuy: (buyer: string, quantity: number) => void }) {
-  const [buyer, setBuyer] = useState("");
-  const [qty, setQty] = useState<number>(1);
-  return (
-    <div className="rounded-xl border p-3 bg-white">
-      <div className="font-semibold mb-2">Sell sticks</div>
-      <div className="grid grid-cols-3 gap-2 items-center">
-        <input className="input col-span-2 text-left" placeholder="Buyer name (optional)" value={buyer}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setBuyer(e.target.value)} />
-        <input className="input input-sm" type="number" min={1} max={10} value={qty}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setQty(clampInt(e.target.value, 1, 10))} />
-      </div>
-      <div className="flex gap-2 mt-2">
-        <button className="btn flex-1" onClick={() => onBuy(buyer, qty)}>Buy</button>
-        <button className="btn-ghost" onClick={() => { setBuyer(""); setQty(1); }}>Clear</button>
-      </div>
-    </div>
-  );
-}
-
-function ScoreSetter({ active, results, onSet, onClear }: {
-  active: Matchup;
-  results: ResultsMap;
-  onSet: (homeScore: number, awayScore: number) => void;
-  onClear: () => void;
-}) {
-  const r = results[active.id] ?? null;
-  const [hs, setHs] = useState<string | number>(r?.homeScore ?? "");
-  const [as, setAs] = useState<string | number>(r?.awayScore ?? "");
-
-  useEffect(() => { // sync when switching games
-    const rr = results[active.id] ?? null;
-    setHs(rr?.homeScore ?? "");
-    setAs(rr?.awayScore ?? "");
-  }, [active.id, results]);
-
-  return (
-    <div className="grid grid-cols-3 gap-2 items-center">
-      <input className="input input-sm" placeholder={`${active.home} score`} value={hs}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setHs(e.target.value.replace(/[^0-9]/g, ""))} />
-      <input className="input input-sm" placeholder={`${active.away} score`} value={as}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAs(e.target.value.replace(/[^0-9]/g, ""))} />
-      <div className="flex gap-2">
-        <button className="btn" onClick={() => onSet(Number(hs||0), Number(as||0))}>Set</button>
-        <button className="btn-ghost" onClick={onClear}>Clear</button>
-      </div>
-    </div>
-  );
-}
-
-function GroupGrid({ sticks, winDigit }: { sticks: Stick[]; winDigit: number | null }) {
-  const slotMap = new Map(sticks.map(s => [s.number, s] as const));
-  const slots = Array.from({ length: 10 }, (_, i) => ({ num: i, s: slotMap.get(i) || null }));
-  return (
-    <div className="grid grid-cols-5 gap-2">
-      {slots.map(({ num, s }) => (
-        <div
-          key={num}
-          className={"slot " + (winDigit !== null && num === winDigit ? "win" : "")}
-          title={s ? `Buyer: ${s.buyer}\nPaid: $${Number(s.price).toFixed(2)}\nAt: ${fmtDate(s.createdAt)}` : ""}
-        >
-          <div className="text-[11px] opacity-60">#{num}</div>
-          <div className="text-sm">{s ? s.buyer : "—"}</div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// ----------------------------- Utils -----------------------------
-function fmtDate(iso: string): string {
-  if (!iso) return "";
-  try {
-    const d = new Date(iso);
-    const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" };
-    return d.toLocaleString(undefined, opts);
-  } catch { return iso; }
-}
-
-function toNumber(v: unknown): number {
-  const n = Number(v);
-  return Number.isFinite(n) ? n : 0;
-}
-
-function possibleWinnings(groups: number): number { return Math.max(0, Math.floor(Number(groups) || 0)) * 100; }
-
-function toMoney(v: unknown): number {
-  const n = Number(v);
-  if (!Number.isFinite(n) || n < 0) return 0;
-  return Math.round(n * 100) / 100;
-}
-
-function asMoney(n: unknown): number {
-  return Math.round(Number(n || 0) * 100) / 100;
-}
-
-function clampInt(v: number | string, min: number, max: number): number {
-  const n = Math.floor(Number(v));
-  if (!Number.isFinite(n)) return min;
-  return Math.max(min, Math.min(max, n));
-}
-
-// Pure helper for testing totals logic without touching React state
-function calcTotalsForTest({ groups, sticks, pot, prices }: { groups: number; sticks?: number; pot?: number; prices?: number[] }) {
-  const totalCharged = Array.isArray(prices)
-    ? prices.reduce((a, b) => a + (Number(b) || 0), 0)
-    : ((Number(sticks) || 0) * (Number(pot) || 0));
-  const possibleW = possibleWinnings(Number(groups) || 0);
-  return { groups: Number(groups) || 0, totalCharged, possibleW } as const;
 }

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import App from "./App";
+
+export default function AppShell() {
+  // Reserved for future global providers.
+  return <App />;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,7 @@
-import Image from "next/image";
-import styles from "./page.module.css";
-import App from "./App";
+import AppShell from "./AppShell";
 
 export default function Page() {
-  return <App/>;
+  return <AppShell/>;
 }
 
 // export default function Home() {

--- a/src/components/admin/AdminBar.tsx
+++ b/src/components/admin/AdminBar.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState } from "react";
+
+type AdminBarProps = {
+  adminPin: string | null;
+  isAdmin: boolean;
+  onSetPin: (pin: string) => void;
+  onLogin: (pin: string) => void;
+  onLogout: () => void;
+  onClearPin: () => void;
+};
+
+export function AdminBar({ adminPin, isAdmin, onSetPin, onLogin, onLogout, onClearPin }: AdminBarProps) {
+  const [pinInput, setPinInput] = useState("");
+  const [newPin, setNewPin] = useState("");
+
+  return (
+    <div className="mt-3 rounded-xl border p-3 bg-white flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+      <div className="font-semibold">Admin</div>
+      {adminPin ? (
+        <div className="flex gap-2 items-center flex-wrap">
+          <span className="text-sm">Status: <b>{isAdmin ? "Logged in" : "Logged out"}</b></span>
+          {isAdmin ? (
+            <>
+              <button className="btn-ghost" onClick={onLogout}>Logout</button>
+              <button className="btn-ghost" onClick={onClearPin}>Remove PIN</button>
+            </>
+          ) : (
+            <>
+              <input
+                className="input input-sm"
+                placeholder="Enter PIN"
+                value={pinInput}
+                onChange={(e) => setPinInput(e.target.value.replace(/[^0-9]/g, ""))}
+              />
+              <button className="btn" onClick={() => { onLogin(pinInput); setPinInput(""); }}>Login</button>
+            </>
+          )}
+        </div>
+      ) : (
+        <div className="flex gap-2 items-center flex-wrap">
+          <input
+            className="input input-sm"
+            placeholder="Set new PIN (4+ digits)"
+            value={newPin}
+            onChange={(e) => setNewPin(e.target.value.replace(/[^0-9]/g, ""))}
+          />
+          <button className="btn" onClick={() => { onSetPin(newPin); setNewPin(""); }}>Set PIN</button>
+          <span className="text-xs opacity-70">(This PIN stays only on this device)</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/Card.tsx
+++ b/src/components/layout/Card.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from "react";
+
+type CardProps = {
+  title: string;
+  children: ReactNode;
+};
+
+export function Card({ title, children }: CardProps) {
+  return (
+    <div className="card">
+      <h3 className="font-semibold">{title}</h3>
+      {children}
+    </div>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,7 @@
+export function Footer() {
+  return (
+    <div className="mt-8 text-center text-xs text-slate-500">
+      Built fast. Iterate later with auth, payments, live NFL feeds.
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,10 @@
+export function Header() {
+  return (
+    <div className="flex flex-col md:flex-row items-start md:items-center gap-3 md:gap-6">
+      <div>
+        <h1 className="text-2xl md:text-3xl font-bold">Sports Sticks – Mini MVP</h1>
+        <p className="muted">Each group holds numbers 0–9. (home+away) % 10 decides the winner.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/matchups/AddMatchup.tsx
+++ b/src/components/matchups/AddMatchup.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+
+type AddMatchupProps = {
+  onAdd: (home: string, away: string, kickoff: string) => void;
+};
+
+export function AddMatchup({ onAdd }: AddMatchupProps) {
+  const [home, setHome] = useState("");
+  const [away, setAway] = useState("");
+  const [kickoff, setKickoff] = useState("");
+
+  return (
+    <div className="rounded-xl border p-3 bg-white space-y-2">
+      <div className="kckStyle2 text-sm font-medium">Add a matchup</div>
+      <div className="grid grid-cols-2 gap-2">
+        <input
+          className="kckStyle input text-left"
+          placeholder="Home"
+          value={home}
+          onChange={(e) => setHome(e.target.value)}
+        />
+        <input
+          className="kckStyle input text-left"
+          placeholder="Away"
+          value={away}
+          onChange={(e) => setAway(e.target.value)}
+        />
+      </div>
+      <input
+        className="input input-wide text-left"
+        type="datetime-local"
+        value={kickoff}
+        onChange={(e) => setKickoff(e.target.value)}
+      />
+      <button
+        className="btn w-full"
+        onClick={() => {
+          if (!home || !away) {
+            alert("Enter home & away team names");
+            return;
+          }
+          onAdd(home.trim(), away.trim(), kickoff || new Date().toISOString());
+          setHome("");
+          setAway("");
+          setKickoff("");
+        }}
+      >
+        Add
+      </button>
+    </div>
+  );
+}

--- a/src/components/matchups/MatchupPicker.tsx
+++ b/src/components/matchups/MatchupPicker.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Matchup } from "../../lib/types";
+import { fmtDate } from "../../lib/game";
+
+type MatchupPickerProps = {
+  matchups: Matchup[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  onRemove?: (id: string) => void;
+};
+
+export function MatchupPicker({ matchups, activeId, onSelect, onRemove }: MatchupPickerProps) {
+  return (
+    <div className="rounded-xl border p-2 bg-white mb-3 max-h-[240px] overflow-auto">
+      {matchups.length === 0 ? (
+        <div className="text-sm opacity-70 p-2">No matchups yet.</div>
+      ) : (
+        <ul className="space-y-1">
+          {matchups.map((matchup) => (
+            <li key={matchup.id} className="flex items-center justify-between gap-2 p-2 rounded-lg hover:bg-slate-50">
+              <button
+                onClick={() => onSelect(matchup.id)}
+                className={`kckStyle text-sm text-left flex-1 ${activeId === matchup.id ? "font-semibold" : ""}`}
+                title={matchup.kickoff}
+              >
+                {matchup.home} vs {matchup.away}
+                <span className="block text-[11px] opacity-60">{fmtDate(matchup.kickoff)}</span>
+              </button>
+              {onRemove ? (
+                <button className="kckStyle pill pill-ghost" onClick={() => onRemove(matchup.id)}>Remove</button>
+              ) : (
+                <span className="text-[11px] opacity-50">Admin only</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/orders/BuyPanel.tsx
+++ b/src/components/orders/BuyPanel.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+import { clampInt } from "../../lib/game";
+
+type BuyPanelProps = {
+  onBuy: (buyer: string, quantity: number) => void;
+};
+
+export function BuyPanel({ onBuy }: BuyPanelProps) {
+  const [buyer, setBuyer] = useState("");
+  const [qty, setQty] = useState<number>(1);
+
+  return (
+    <div className="rounded-xl border p-3 bg-white">
+      <div className="font-semibold mb-2">Sell sticks</div>
+      <div className="grid grid-cols-3 gap-2 items-center">
+        <input
+          className="input col-span-2 text-left"
+          placeholder="Buyer name (optional)"
+          value={buyer}
+          onChange={(e) => setBuyer(e.target.value)}
+        />
+        <input
+          className="input input-sm"
+          type="number"
+          min={1}
+          max={10}
+          value={qty}
+          onChange={(e) => setQty(clampInt(e.target.value, 1, 10))}
+        />
+      </div>
+      <div className="flex gap-2 mt-2">
+        <button className="btn flex-1" onClick={() => onBuy(buyer, qty)}>Buy</button>
+        <button
+          className="btn-ghost"
+          onClick={() => {
+            setBuyer("");
+            setQty(1);
+          }}
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/orders/GroupGrid.tsx
+++ b/src/components/orders/GroupGrid.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { buildGroupSlots, fmtDate } from "../../lib/game";
+import { Stick } from "../../lib/types";
+
+type GroupGridProps = {
+  sticks: Stick[];
+  winDigit: number | null;
+};
+
+export function GroupGrid({ sticks, winDigit }: GroupGridProps) {
+  const slots = buildGroupSlots(sticks);
+
+  return (
+    <div className="grid grid-cols-5 gap-2">
+      {slots.map(({ num, stick }) => (
+        <div
+          key={num}
+          className={`slot ${winDigit !== null && num === winDigit ? "win" : ""}`}
+          title={stick ? `Buyer: ${stick.buyer}\nPaid: $${Number(stick.price).toFixed(2)}\nAt: ${fmtDate(stick.createdAt)}` : ""}
+        >
+          <div className="text-[11px] opacity-60">#{num}</div>
+          <div className="text-sm">{stick ? stick.buyer : "—"}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/orders/ScoreSetter.tsx
+++ b/src/components/orders/ScoreSetter.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Matchup, ResultsEntry } from "../../lib/types";
+
+type ScoreSetterProps = {
+  matchup: Matchup;
+  result: ResultsEntry;
+  onSet: (homeScore: number, awayScore: number) => void;
+  onClear: () => void;
+};
+
+export function ScoreSetter({ matchup, result, onSet, onClear }: ScoreSetterProps) {
+  const [homeScore, setHomeScore] = useState<string | number>(result?.homeScore ?? "");
+  const [awayScore, setAwayScore] = useState<string | number>(result?.awayScore ?? "");
+
+  useEffect(() => {
+    setHomeScore(result?.homeScore ?? "");
+    setAwayScore(result?.awayScore ?? "");
+  }, [result?.homeScore, result?.awayScore]);
+
+  return (
+    <div className="grid grid-cols-3 gap-2 items-center">
+      <input
+        className="input input-sm"
+        placeholder={`${matchup.home} score`}
+        value={homeScore}
+        onChange={(e) => setHomeScore(e.target.value.replace(/[^0-9]/g, ""))}
+      />
+      <input
+        className="input input-sm"
+        placeholder={`${matchup.away} score`}
+        value={awayScore}
+        onChange={(e) => setAwayScore(e.target.value.replace(/[^0-9]/g, ""))}
+      />
+      <div className="flex gap-2">
+        <button className="btn" onClick={() => onSet(Number(homeScore || 0), Number(awayScore || 0))}>Set</button>
+        <button className="btn-ghost" onClick={onClear}>Clear</button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useMatchups.ts
+++ b/src/hooks/useMatchups.ts
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { STORAGE_KEYS, load, save, uid } from "../lib/storage";
+import { Matchup } from "../lib/types";
+
+export type ViewMode = "home" | "game";
+
+type AddMatchupPayload = {
+  home: string;
+  away: string;
+  kickoff: string;
+};
+
+const createSampleMatchups = (): Matchup[] => [
+  { id: uid(), home: "Bengals", away: "Steelers", kickoff: "2025-09-07T13:00:00" },
+  { id: uid(), home: "Chiefs", away: "Ravens", kickoff: "2025-09-07T16:25:00" },
+  { id: uid(), home: "49ers", away: "Cowboys", kickoff: "2025-09-08T20:20:00" },
+];
+
+const SAMPLE_MATCHUPS = createSampleMatchups();
+
+type HydratePayload = {
+  matchups?: Matchup[];
+  activeId?: string | null;
+  view?: ViewMode;
+};
+
+export const useMatchups = () => {
+  const [matchups, setMatchups] = useState<Matchup[]>(() => load(STORAGE_KEYS.matchups, SAMPLE_MATCHUPS));
+  const [activeId, setActiveIdState] = useState<string | null>(() => load(STORAGE_KEYS.activeId, matchups[0]?.id ?? null));
+  const [view, setViewState] = useState<ViewMode>(() => load(STORAGE_KEYS.view, "home"));
+
+  useEffect(() => save(STORAGE_KEYS.matchups, matchups), [matchups]);
+  useEffect(() => save(STORAGE_KEYS.activeId, activeId), [activeId]);
+  useEffect(() => save(STORAGE_KEYS.view, view), [view]);
+
+  const activeMatchup = useMemo<Matchup | null>(() => matchups.find((m) => m.id === activeId) ?? null, [matchups, activeId]);
+
+  const setActiveId = useCallback((id: string | null) => {
+    setActiveIdState(id);
+  }, []);
+
+  const setView = useCallback((next: ViewMode) => {
+    setViewState(next);
+  }, []);
+
+  const addMatchup = useCallback(({ home, away, kickoff }: AddMatchupPayload) => {
+    const matchup: Matchup = { id: uid(), home, away, kickoff };
+    setMatchups((prev) => [matchup, ...prev]);
+    setActiveIdState(matchup.id);
+    setViewState("game");
+    return matchup;
+  }, []);
+
+  const removeMatchup = useCallback((id: string) => {
+    setMatchups((prev) => {
+      const next = prev.filter((m) => m.id !== id);
+      setActiveIdState((current) => {
+        if (current === id) {
+          return next[0]?.id ?? null;
+        }
+        return current;
+      });
+      setViewState((current) => {
+        if (current === "game" && (activeId === id || !next.find((m) => m.id === activeId))) {
+          return "home";
+        }
+        return current;
+      });
+      return next;
+    });
+  }, [activeId]);
+
+  const hydrate = useCallback(({ matchups: nextMatchups, activeId: nextActiveId, view: nextView }: HydratePayload) => {
+    if (nextMatchups) {
+      setMatchups(nextMatchups);
+    }
+    if (typeof nextActiveId !== "undefined") {
+      setActiveIdState(nextActiveId);
+    }
+    if (nextView) {
+      setViewState(nextView);
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    const samples = createSampleMatchups();
+    setMatchups(samples);
+    setActiveIdState(samples[0]?.id ?? null);
+    setViewState("home");
+  }, []);
+
+  return {
+    matchups,
+    activeId,
+    view,
+    activeMatchup,
+    setActiveId,
+    setView,
+    addMatchup,
+    removeMatchup,
+    hydrate,
+    reset,
+  } as const;
+};
+
+export { SAMPLE_MATCHUPS };

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useState } from "react";
+import { STORAGE_KEYS, load, save, uid } from "../lib/storage";
+import { Group, OrdersMap, ResultsMap } from "../lib/types";
+import { asMoney, clampInt, countStickTotals } from "../lib/game";
+
+type BuyStickPayload = {
+  matchupId: string;
+  buyer: string;
+  quantity: number;
+  pricePerStick: number;
+};
+
+type HydratePayload = {
+  orders?: OrdersMap;
+  results?: ResultsMap;
+};
+
+export const useOrders = () => {
+  const [orders, setOrders] = useState<OrdersMap>(() => load(STORAGE_KEYS.orders, {}));
+  const [results, setResults] = useState<ResultsMap>(() => load(STORAGE_KEYS.results, {}));
+
+  useEffect(() => save(STORAGE_KEYS.orders, orders), [orders]);
+  useEffect(() => save(STORAGE_KEYS.results, results), [results]);
+
+  const groupsForMatchup = useCallback(
+    (matchupId: string | null): Group[] => {
+      if (!matchupId) return [];
+      return orders[matchupId] ?? [];
+    },
+    [orders],
+  );
+
+  const totalsForMatchup = useCallback(
+    (matchupId: string | null) => {
+      const groups = groupsForMatchup(matchupId);
+      return countStickTotals(groups);
+    },
+    [groupsForMatchup],
+  );
+
+  const buySticks = useCallback(
+    ({ matchupId, buyer, quantity, pricePerStick }: BuyStickPayload) => {
+      const normalizedBuyer = buyer.trim() || "Guest";
+      const q = clampInt(quantity, 1, 10);
+      const price = asMoney(pricePerStick);
+      if (!matchupId) return;
+
+      setOrders((prev) => {
+        const groups: Group[] = [...(prev[matchupId] ?? [])];
+        const nowIso = new Date().toISOString();
+        let remaining = q;
+
+        while (remaining > 0) {
+          if (groups.length === 0 || groups[groups.length - 1].sticks.length >= 10) {
+            groups.push({ id: uid(), sticks: [] });
+          }
+          const group = groups[groups.length - 1];
+          const takenNums = new Set(group.sticks.map((s) => s.number));
+          const available = Array.from({ length: 10 }, (_, i) => i).filter((n) => !takenNums.has(n));
+          if (available.length === 0) {
+            break;
+          }
+          const toPlace = Math.min(available.length, remaining);
+          for (let i = 0; i < toPlace; i += 1) {
+            const index = Math.floor(Math.random() * available.length);
+            const num = available.splice(index, 1)[0];
+            group.sticks.push({
+              id: uid(),
+              buyer: normalizedBuyer,
+              number: num,
+              price,
+              fee: 0,
+              createdAt: nowIso,
+            });
+            remaining -= 1;
+          }
+        }
+
+        return { ...prev, [matchupId]: groups } as OrdersMap;
+      });
+    },
+    [],
+  );
+
+  const setScores = useCallback((matchupId: string, homeScore: number, awayScore: number) => {
+    setResults((prev) => {
+      const hs = clampInt(homeScore, 0, Number.MAX_SAFE_INTEGER);
+      const as = clampInt(awayScore, 0, Number.MAX_SAFE_INTEGER);
+      const digit = (hs + as) % 10;
+      return { ...prev, [matchupId]: { homeScore: hs, awayScore: as, digit } } as ResultsMap;
+    });
+  }, []);
+
+  const clearScores = useCallback((matchupId: string) => {
+    setResults((prev) => ({ ...prev, [matchupId]: null }));
+  }, []);
+
+  const clearMatchupData = useCallback((matchupId: string) => {
+    setOrders((prev) => {
+      if (!prev[matchupId]) return prev;
+      const next = { ...prev };
+      delete next[matchupId];
+      return next;
+    });
+    setResults((prev) => {
+      if (!(matchupId in prev)) return prev;
+      const next = { ...prev } as ResultsMap;
+      delete next[matchupId];
+      return next;
+    });
+  }, []);
+
+  const hydrate = useCallback(({ orders: nextOrders, results: nextResults }: HydratePayload) => {
+    if (nextOrders) {
+      setOrders(nextOrders);
+    }
+    if (nextResults) {
+      setResults(nextResults);
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    setOrders({});
+    setResults({});
+  }, []);
+
+  const winDigitForMatchup = useCallback(
+    (matchupId: string | null) => {
+      if (!matchupId) return null;
+      return results[matchupId]?.digit ?? null;
+    },
+    [results],
+  );
+
+  return {
+    orders,
+    results,
+    groupsForMatchup,
+    totalsForMatchup,
+    buySticks,
+    setScores,
+    clearScores,
+    clearMatchupData,
+    hydrate,
+    reset,
+    winDigitForMatchup,
+  } as const;
+};

--- a/src/lib/game.ts
+++ b/src/lib/game.ts
@@ -1,0 +1,80 @@
+import { Group, Stick } from "./types";
+
+export function fmtDate(iso: string): string {
+  if (!iso) return "";
+  try {
+    const d = new Date(iso);
+    const opts: Intl.DateTimeFormatOptions = {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    };
+    return d.toLocaleString(undefined, opts);
+  } catch {
+    return iso;
+  }
+}
+
+export function toNumber(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function possibleWinnings(groups: number): number {
+  return Math.max(0, Math.floor(Number(groups) || 0)) * 100;
+}
+
+export function toMoney(v: unknown): number {
+  const n = Number(v);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.round(n * 100) / 100;
+}
+
+export function asMoney(v: unknown): number {
+  return Math.round(Number(v || 0) * 100) / 100;
+}
+
+export function clampInt(v: number | string, min: number, max: number): number {
+  const n = Math.floor(Number(v));
+  if (!Number.isFinite(n)) return min;
+  return Math.max(min, Math.min(max, n));
+}
+
+export function calcTotalsForTest({
+  groups,
+  sticks,
+  pot,
+  prices,
+}: {
+  groups: number;
+  sticks?: number;
+  pot?: number;
+  prices?: number[];
+}) {
+  const totalCharged = Array.isArray(prices)
+    ? prices.reduce((a, b) => a + (Number(b) || 0), 0)
+    : (Number(sticks) || 0) * (Number(pot) || 0);
+  const possibleW = possibleWinnings(Number(groups) || 0);
+  return { groups: Number(groups) || 0, totalCharged, possibleW } as const;
+}
+
+export function buildGroupSlots(sticks: Stick[]): { num: number; stick: Stick | null }[] {
+  const slotMap = new Map(sticks.map((s) => [s.number, s] as const));
+  return Array.from({ length: 10 }, (_, i) => ({ num: i, stick: slotMap.get(i) ?? null }));
+}
+
+export function countStickTotals(groups: Group[]): {
+  groups: number;
+  sticks: number;
+  totalCharged: number;
+  possibleW: number;
+} {
+  const sticks = groups.reduce((sum, g) => sum + g.sticks.length, 0);
+  const totalCharged = groups.reduce(
+    (sum, g) => sum + g.sticks.reduce((inner, stick) => inner + toNumber(stick.price), 0),
+    0,
+  );
+  const possibleW = possibleWinnings(groups.length);
+  return { groups: groups.length, sticks, totalCharged, possibleW };
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,27 @@
+export const STORAGE_KEYS = {
+  matchups: "ss_matchups",
+  activeId: "ss_activeId",
+  config: "ss_config_v2",
+  orders: "ss_orders_v2",
+  results: "ss_results_v2",
+  adminPin: "ss_admin_pin_v1",
+  adminSession: "ss_admin_session_v1",
+  view: "ss_view_v1",
+} as const;
+
+export const uid = (): string => Math.random().toString(36).slice(2, 9);
+
+export const save = <T,>(key: string, val: T): void => {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(key, JSON.stringify(val));
+};
+
+export const load = <T,>(key: string, fallback: T): T => {
+  if (typeof window === "undefined") return fallback;
+  try {
+    const value = localStorage.getItem(key);
+    return value ? (JSON.parse(value) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,34 @@
+export type Matchup = {
+  id: string;
+  home: string;
+  away: string;
+  kickoff: string;
+};
+
+export type Stick = {
+  id: string;
+  buyer: string;
+  number: number;
+  price: number;
+  fee: number;
+  createdAt: string;
+};
+
+export type Group = {
+  id: string;
+  sticks: Stick[];
+};
+
+export type OrdersMap = Record<string, Group[]>;
+
+export type ResultsEntry = {
+  homeScore: number;
+  awayScore: number;
+  digit: number;
+} | null;
+
+export type ResultsMap = Record<string, ResultsEntry>;
+
+export type Config = {
+  potPerStick: number;
+};


### PR DESCRIPTION
## Summary
- split the monolithic app into modular layout, admin, matchup, and order components wired through a new AppShell entrypoint
- extracted shared hooks for matchup/order persistence and shared storage/game utilities under src/lib
- simplified the page container to orchestrate state via hooks while keeping the visual output unchanged

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1c2644484832eb326acaf7b12c413