### PR TITLE
Add API helper for frontend requests

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,11 @@
+const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+export async function api<T = any>(path: string, options: RequestInit = {}): Promise<T> {
+  const token = typeof window !== "undefined" ? localStorage.getItem("jwt") : null;
+  const headers = new Headers(options.headers || {});
+  headers.set("Content-Type", "application/json");
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+  const res = await fetch(`${API}${path}`, { ...options, headers });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add a shared API helper that automatically prepends the configured backend URL
- include JWT support by setting the Authorization header when a token is present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e716128ddc832e815de891752730a1