### PR TITLE
Add login and register pages

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { useState } from "react";
+import { api } from "@/lib/api";
+
+export default function LoginPage() {
+  const [emailOrPhone, setId] = useState("");
+  const [password, setPw] = useState("");
+  const [msg, setMsg] = useState("");
+
+  async function submit(e: any) {
+    e.preventDefault();
+    try {
+      const res = await api("/auth/login", {
+        method: "POST",
+        body: JSON.stringify({ emailOrPhone, password }),
+      });
+      localStorage.setItem("jwt", res.token);
+      setMsg("Logged in. Token saved.");
+    } catch (e: any) {
+      setMsg(e.message);
+    }
+  }
+
+  return (
+    <form onSubmit={submit} style={{ display: "grid", gap: 8, maxWidth: 360, padding: 16 }}>
+      <input placeholder="email or phone" value={emailOrPhone} onChange={e => setId(e.target.value)} />
+      <input placeholder="password" type="password" value={password} onChange={e => setPw(e.target.value)} />
+      <button type="submit">Login</button>
+      <div>{msg}</div>
+    </form>
+  );
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+import { useState } from "react";
+import { api } from "@/lib/api";
+
+export default function RegisterPage() {
+  const [emailOrPhone, setId] = useState("");
+  const [password, setPw] = useState("");
+  const [token, setToken] = useState(""); // invite token (optional UI)
+  const [msg, setMsg] = useState("");
+
+  async function submit(e: any) {
+    e.preventDefault();
+    try {
+      const res = await api("/auth/register", {
+        method: "POST",
+        body: JSON.stringify({ emailOrPhone, password, token }),
+      });
+      localStorage.setItem("jwt", res.token);
+      setMsg("Registered. Token saved.");
+    } catch (e: any) {
+      setMsg(e.message);
+    }
+  }
+
+  return (
+    <form onSubmit={submit} style={{ display: "grid", gap: 8, maxWidth: 360, padding: 16 }}>
+      <input placeholder="email or phone" value={emailOrPhone} onChange={e => setId(e.target.value)} />
+      <input placeholder="password" type="password" value={password} onChange={e => setPw(e.target.value)} />
+      <input placeholder="invite token (optional)" value={token} onChange={e => setToken(e.target.value)} />
+      <button type="submit">Register</button>
+      <div>{msg}</div>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add a register page that submits invite tokens and stores the returned JWT
- add a login page that authenticates existing users and stores the returned JWT

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e716324230832e81985fc9dff746cd