### PR TITLE
Add client page for /me

### DIFF
--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+export default function MePage() {
+  const [data, setData] = useState<any>(null);
+  const [err, setErr] = useState("");
+
+  useEffect(() => {
+    api("/me")
+      .then(setData)
+      .catch((e) => setErr(String(e)));
+  }, []);
+
+  return <pre style={{ padding: 16 }}>{err ? err : JSON.stringify(data, null, 2)}</pre>;
+}


### PR DESCRIPTION
## Summary
- add a client-side /me page that fetches the current user data
- display either the JSON response or an error message

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e716517948832e93dbc11ca8768d15