### PR TITLE
feat: standardize form inputs across auth and admin

### DIFF
--- a/src/app/admin/admin.module.css
+++ b/src/app/admin/admin.module.css
@@ -108,21 +108,6 @@
   color: rgba(15, 23, 42, 0.85);
 }
 
-.input {
-  width: 100%;
-  padding: 0.75rem 1rem;
-  border-radius: 0.85rem;
-  border: 1px solid rgba(148, 163, 184, 0.5);
-  font-size: 1rem;
-  transition: border 0.2s ease, box-shadow 0.2s ease;
-}
-
-.input:focus {
-  outline: none;
-  border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
-}
-
 .fullWidth {
   grid-column: 1 / -1;
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 
 import { MatchupPicker } from "@/components/matchups/MatchupPicker";
 import { useSportsSticks } from "@/components/providers/SportsSticksProvider";
+import { Input } from "@/components/ui/Input";
 import { useAuth } from "@/context/AuthContext";
 
 import styles from "./admin.module.css";
@@ -133,8 +134,7 @@ export default function AdminPage() {
           <div className={styles.fieldRow}>
             <label className={styles.field}>
               <span>Home team</span>
-              <input
-                className={styles.input}
+              <Input
                 value={homeTeam}
                 onChange={(event) => setHomeTeam(event.target.value)}
                 placeholder="Home team"
@@ -142,8 +142,7 @@ export default function AdminPage() {
             </label>
             <label className={styles.field}>
               <span>Away team</span>
-              <input
-                className={styles.input}
+              <Input
                 value={awayTeam}
                 onChange={(event) => setAwayTeam(event.target.value)}
                 placeholder="Away team"
@@ -152,9 +151,8 @@ export default function AdminPage() {
           </div>
           <label className={`${styles.field} ${styles.fullWidth}`}>
             <span>Kickoff</span>
-            <input
+            <Input
               type="datetime-local"
-              className={styles.input}
               value={kickoff}
               onChange={(event) => setKickoff(event.target.value)}
             />

--- a/src/app/auth.module.css
+++ b/src/app/auth.module.css
@@ -37,21 +37,6 @@
   font-size: 0.9rem;
 }
 
-.input {
-  width: 100%;
-  padding: 0.75rem 1rem;
-  border-radius: 0.85rem;
-  border: 1px solid rgba(148, 163, 184, 0.5);
-  font-size: 1rem;
-  transition: border 0.2s ease, box-shadow 0.2s ease;
-}
-
-.input:focus {
-  outline: none;
-  border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
-}
-
 .submit {
   display: inline-flex;
   justify-content: center;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,6 +24,51 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+.form-input {
+  width: 100%;
+  appearance: none;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(255, 255, 255, 0.97);
+  color: rgba(15, 23, 42, 0.92);
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.form-input::placeholder {
+  color: rgba(100, 116, 139, 0.7);
+}
+
+.form-input:hover:not(:disabled) {
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.99);
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18), 0 16px 32px rgba(15, 23, 42, 0.1);
+  background: #ffffff;
+}
+
+.form-input:focus-visible {
+  outline: none;
+}
+
+.form-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.form-input--invalid {
+  border-color: #dc2626;
+  box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.15), 0 14px 28px rgba(220, 38, 38, 0.08);
+}
+
 * {
   box-sizing: border-box;
   padding: 0;

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import styles from "../auth.module.css";
+import { Input } from "@/components/ui/Input";
 import { useAuth } from "@/context/AuthContext";
 
 export default function LoginPage() {
@@ -43,12 +44,11 @@ export default function LoginPage() {
       <form className={styles.form} onSubmit={handleSubmit}>
         <label className={styles.label} htmlFor="email">
           Email
-          <input
+          <Input
             id="email"
             type="email"
             inputMode="email"
             autoComplete="email"
-            className={styles.input}
             value={email}
             onChange={(event) => setEmail(event.target.value)}
             placeholder="you@example.com"

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import styles from "../auth.module.css";
+import { Input } from "@/components/ui/Input";
 import { useAuth } from "@/context/AuthContext";
 
 export default function RegisterPage() {
@@ -45,11 +46,10 @@ export default function RegisterPage() {
       <form className={styles.form} onSubmit={handleSubmit}>
         <label className={styles.label} htmlFor="name">
           Name
-          <input
+          <Input
             id="name"
             type="text"
             autoComplete="name"
-            className={styles.input}
             value={name}
             onChange={(event) => setName(event.target.value)}
             placeholder="Jordan Stickhandler"
@@ -59,12 +59,11 @@ export default function RegisterPage() {
 
         <label className={styles.label} htmlFor="email">
           Email
-          <input
+          <Input
             id="email"
             type="email"
             inputMode="email"
             autoComplete="email"
-            className={styles.input}
             value={email}
             onChange={(event) => setEmail(event.target.value)}
             placeholder="you@example.com"

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,27 @@
+import { forwardRef, InputHTMLAttributes } from "react";
+
+export type InputProps = InputHTMLAttributes<HTMLInputElement> & {
+  isInvalid?: boolean;
+};
+
+const baseClassName = "form-input";
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className = "", isInvalid, ...props }, ref) => {
+    const classes = [baseClassName];
+
+    if (isInvalid) {
+      classes.push("form-input--invalid");
+    }
+
+    if (className) {
+      classes.push(className);
+    }
+
+    return <input ref={ref} className={classes.join(" ")} {...props} />;
+  },
+);
+
+Input.displayName = "Input";
+
+export default Input;


### PR DESCRIPTION
## Summary
- add a shared Input component that encapsulates the light form styling from the Buy Sticks modal
- replace the admin, login, and register form fields to use the new component and global styles for consistency
- clean up old module-level input styles now that forms share a unified look

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e93c29d880832e97fbf56747c5cb9a