### PR TITLE
Add admin invites management page

### DIFF
--- a/src/app/admin/invites/page.tsx
+++ b/src/app/admin/invites/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+import SiteShell from "@/components/layout/SiteShell";
+import { InviteForm } from "@/components/admin/invites/InviteForm";
+import { InviteTable } from "@/components/admin/invites/InviteTable";
+import { InviteQrModal } from "@/components/admin/invites/InviteQrModal";
+import { useAuth } from "@/context/AuthContext";
+import type { Invite } from "@/types/invite";
+
+export default function AdminInvitesPage() {
+  const { user } = useAuth();
+  const isAdminUser = user?.role === "admin";
+  const [refreshToken, setRefreshToken] = useState(0);
+  const [qrInvite, setQrInvite] = useState<Invite | null>(null);
+
+  if (!isAdminUser) {
+    return (
+      <SiteShell>
+        <div className="mt-6 space-y-4">
+          <section className="ssg-card space-y-3">
+            <h1 className="text-xl font-semibold">403 – Friendly stick block</h1>
+            <p className="text-sm text-slate-600">You need an admin account to access this dashboard.</p>
+            <Link href="/" className="ssg-btn ssg-btn-sm" aria-label="Return to matchups">
+              Return home
+            </Link>
+          </section>
+        </div>
+      </SiteShell>
+    );
+  }
+
+  return (
+    <SiteShell>
+      <div className="mt-6 space-y-4">
+        <header className="space-y-1">
+          <h1 className="text-2xl font-semibold text-slate-900">Invites</h1>
+          <p className="text-sm text-slate-600">
+            Send invites for new players and monitor how they move from pending to registered.
+          </p>
+        </header>
+
+        <InviteForm
+          onCreated={(invite) => {
+            setRefreshToken((token) => token + 1);
+            setQrInvite(invite);
+          }}
+          onShowQr={(invite) => setQrInvite(invite)}
+        />
+
+        <InviteTable
+          refreshToken={refreshToken}
+          onShowQr={(invite) => {
+            setQrInvite(invite);
+          }}
+        />
+      </div>
+      <InviteQrModal invite={qrInvite} open={qrInvite !== null} onClose={() => setQrInvite(null)} />
+    </SiteShell>
+  );
+}

--- a/src/components/admin/invites/InviteForm.tsx
+++ b/src/components/admin/invites/InviteForm.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import type { CreateInvitePayload, Invite, InviteChannel } from "@/types/invite";
+import { createInvite } from "@/lib/api/invites";
+
+interface InviteFormProps {
+  onCreated(invite: Invite): void;
+  onShowQr(invite: Invite): void;
+}
+
+type Feedback = { type: "success" | "error"; message: string } | null;
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const E164_RE = /^\+[1-9]\d{6,14}$/;
+
+const nextWeek = () => {
+  const expires = new Date();
+  expires.setDate(expires.getDate() + 7);
+  expires.setMinutes(0, 0, 0);
+  return expires.toISOString().slice(0, 16);
+};
+
+export function InviteForm({ onCreated, onShowQr }: InviteFormProps) {
+  const [channel, setChannel] = useState<InviteChannel>("email");
+  const [recipient, setRecipient] = useState("");
+  const [expiresAt, setExpiresAt] = useState<string>(() => nextWeek());
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [feedback, setFeedback] = useState<Feedback>(null);
+  const [lastInvite, setLastInvite] = useState<Invite | null>(null);
+
+  useEffect(() => {
+    if (!feedback) return;
+    const timer = setTimeout(() => setFeedback(null), 3600);
+    return () => clearTimeout(timer);
+  }, [feedback]);
+
+  const recipientLabel = useMemo(() => {
+    switch (channel) {
+      case "email":
+        return "Recipient email";
+      case "sms":
+        return "Recipient phone";
+      default:
+        return "Share manually";
+    }
+  }, [channel]);
+
+  const handleChannelChange = (value: InviteChannel) => {
+    setChannel(value);
+    setRecipient("");
+  };
+
+  const validateRecipient = () => {
+    if (channel === "link") return true;
+    if (!recipient.trim()) return false;
+    if (channel === "email") {
+      return EMAIL_RE.test(recipient.trim().toLowerCase());
+    }
+    return E164_RE.test(recipient.trim());
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isSubmitting) return;
+
+    const validRecipient = validateRecipient();
+    if (!validRecipient) {
+      setFeedback({ type: "error", message: "Enter a valid recipient." });
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const payload: CreateInvitePayload = { channel };
+      if (channel !== "link") {
+        payload.recipient = recipient.trim();
+      }
+      if (expiresAt) {
+        payload.expiresAt = new Date(expiresAt).toISOString();
+      }
+      const invite = await createInvite(payload);
+      setLastInvite(invite);
+      onCreated(invite);
+      setFeedback({ type: "success", message: "Invite created successfully." });
+      if (channel !== "link") {
+        setRecipient("");
+      }
+    } catch (error) {
+      setFeedback({ type: "error", message: error instanceof Error ? error.message : "Failed to create invite." });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="ssg-card space-y-4" aria-labelledby="invite-form-heading">
+      <div className="space-y-1">
+        <h2 id="invite-form-heading" className="text-lg font-semibold">
+          Send invite
+        </h2>
+        <p className="text-sm text-slate-500">Email, SMS, or link-only invites for quick registration.</p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <fieldset className="space-y-2" aria-label="Invite channel">
+          <span className="text-sm font-medium text-slate-600">Delivery method</span>
+          <div className="flex flex-wrap gap-2" role="radiogroup">
+            {(
+              [
+                { value: "email", label: "Email" },
+                { value: "sms", label: "SMS" },
+                { value: "link", label: "Link only" },
+              ] as const satisfies readonly { value: InviteChannel; label: string }[]
+            ).map(({ value, label }) => {
+              const isActive = channel === value;
+              return (
+                <button
+                  key={value}
+                  type="button"
+                  className="ssg-btn"
+                  onClick={() => handleChannelChange(value)}
+                  aria-pressed={isActive}
+                  style={{
+                    background: isActive ? "#111827" : "#ffffff",
+                    color: isActive ? "#ffffff" : "#0f172a",
+                    borderColor: isActive ? "#0f172a" : "rgba(148, 163, 184, 0.45)",
+                  }}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        </fieldset>
+
+        {channel !== "link" ? (
+          <label className="flex flex-col space-y-2">
+            <span className="text-sm font-medium text-slate-600">{recipientLabel}</span>
+            <input
+              className="ssg-input"
+              placeholder={channel === "email" ? "name@example.com" : "+15551234567"}
+              value={recipient}
+              onChange={(event) => setRecipient(event.target.value)}
+              required={channel !== "link"}
+              aria-invalid={feedback?.type === "error" && !validateRecipient()}
+            />
+            <span className="text-xs text-slate-500">
+              {channel === "sms"
+                ? "Use E.164 format, e.g. +15551234567"
+                : "We\'ll send the registration link immediately."}
+            </span>
+          </label>
+        ) : null}
+
+        <label className="flex flex-col space-y-2" style={{ maxWidth: "260px" }}>
+          <span className="text-sm font-medium text-slate-600">Expires</span>
+          <input
+            type="datetime-local"
+            className="ssg-input"
+            value={expiresAt}
+            onChange={(event) => setExpiresAt(event.target.value)}
+          />
+          <span className="text-xs text-slate-500">Invites automatically deactivate after this time.</span>
+        </label>
+
+        <div className="flex justify-end">
+          <button type="submit" className="ssg-btn-dark" disabled={isSubmitting}>
+            {isSubmitting ? "Sending…" : "Create invite"}
+          </button>
+        </div>
+      </form>
+
+      {feedback ? (
+        <div
+          className="rounded-xl border p-3 text-sm font-medium"
+          style={{
+            background: feedback.type === "success" ? "rgba(16, 185, 129, 0.12)" : "rgba(239, 68, 68, 0.12)",
+            borderColor: feedback.type === "success" ? "rgba(16, 185, 129, 0.4)" : "rgba(239, 68, 68, 0.45)",
+            color: feedback.type === "success" ? "#047857" : "#b91c1c",
+          }}
+        >
+          {feedback.message}
+          {feedback.type === "success" && lastInvite ? (
+            <div className="mt-2 space-y-2">
+              <button
+                type="button"
+                className="ssg-btn ssg-btn-sm"
+                onClick={() => {
+                  if (navigator.clipboard && "writeText" in navigator.clipboard) {
+                    void navigator.clipboard.writeText(lastInvite.inviteUrl);
+                  } else {
+                    window.prompt("Invite link", lastInvite.inviteUrl);
+                  }
+                }}
+              >
+                Copy link
+              </button>
+              <button type="button" className="ssg-btn ssg-btn-sm" onClick={() => onShowQr(lastInvite)}>
+                Show QR
+              </button>
+              <div className="text-xs opacity-70 break-all">{lastInvite.inviteUrl}</div>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/admin/invites/InviteQrModal.tsx
+++ b/src/components/admin/invites/InviteQrModal.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect } from "react";
+
+import type { Invite } from "@/types/invite";
+
+interface InviteQrModalProps {
+  invite: Invite | null;
+  open: boolean;
+  onClose(): void;
+}
+
+export function InviteQrModal({ invite, open, onClose }: InviteQrModalProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose]);
+
+  if (!open || !invite) return null;
+
+  const qrSrc = `https://api.qrserver.com/v1/create-qr-code/?size=256x256&data=${encodeURIComponent(invite.inviteUrl)}`;
+  const trackingUrl = `/api/invites/track/${invite.code}`;
+
+  return (
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="invite-qr-heading" onClick={onClose}>
+      <div className="modal-panel space-y-4" onClick={(event) => event.stopPropagation()}>
+        <button type="button" className="modal-close" aria-label="Close QR code" onClick={onClose}>
+          ×
+        </button>
+        <div className="space-y-1">
+          <h2 id="invite-qr-heading" className="text-lg font-semibold">
+            Invite QR code
+          </h2>
+          <p className="text-sm text-slate-500">Scan to open the invite link instantly.</p>
+        </div>
+        <div className="flex flex-col items-center gap-3">
+          <div className="rounded-3xl border bg-white p-4" style={{ borderColor: "rgba(148, 163, 184, 0.45)" }}>
+            <Image src={qrSrc} alt="Invite QR code" width={224} height={224} className="h-56 w-56" unoptimized />
+          </div>
+          <div className="text-xs text-slate-500 break-all text-center">{invite.inviteUrl}</div>
+        </div>
+        <div className="flex flex-wrap justify-end gap-2">
+          <a
+            href={trackingUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ssg-btn"
+            aria-label="Open invite tracking link"
+          >
+            Open tracking link
+          </a>
+          <button
+            type="button"
+            className="ssg-btn-dark"
+            onClick={() => {
+              window.open(invite.inviteUrl, "_blank", "noopener,noreferrer");
+            }}
+          >
+            Open invite link
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/invites/InviteTable.tsx
+++ b/src/components/admin/invites/InviteTable.tsx
@@ -1,0 +1,328 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type { Invite, InviteStatus } from "@/types/invite";
+import { listInvites, resendInvite, updateInvite } from "@/lib/api/invites";
+
+interface InviteTableProps {
+  onShowQr(invite: Invite): void;
+  refreshToken: number;
+}
+
+interface InviteRowAction {
+  label: string;
+  onAction: (invite: Invite) => Promise<void> | void;
+  isDisabled?: (invite: Invite) => boolean;
+}
+
+const STATUS_LABEL: Record<InviteStatus, string> = {
+  pending: "Pending",
+  clicked: "Clicked",
+  accepted: "Accepted",
+  registered: "Registered",
+  revoked: "Revoked",
+  expired: "Expired",
+};
+
+const STATUS_STYLES: Record<InviteStatus, { background: string; borderColor: string; color: string }> = {
+  pending: {
+    background: "rgba(148, 163, 184, 0.12)",
+    borderColor: "rgba(148, 163, 184, 0.45)",
+    color: "#475569",
+  },
+  clicked: {
+    background: "rgba(59, 130, 246, 0.12)",
+    borderColor: "rgba(59, 130, 246, 0.35)",
+    color: "#1d4ed8",
+  },
+  accepted: {
+    background: "rgba(168, 85, 247, 0.12)",
+    borderColor: "rgba(168, 85, 247, 0.35)",
+    color: "#6b21a8",
+  },
+  registered: {
+    background: "rgba(34, 197, 94, 0.12)",
+    borderColor: "rgba(34, 197, 94, 0.35)",
+    color: "#15803d",
+  },
+  revoked: {
+    background: "rgba(239, 68, 68, 0.12)",
+    borderColor: "rgba(239, 68, 68, 0.4)",
+    color: "#b91c1c",
+  },
+  expired: {
+    background: "rgba(113, 113, 122, 0.12)",
+    borderColor: "rgba(113, 113, 122, 0.3)",
+    color: "#44403c",
+  },
+};
+
+const PAGE_SIZE = 10;
+
+function formatDate(value: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function formatRecipient(invite: Invite) {
+  if (invite.channel === "link" || !invite.recipient) return "Link only";
+  return invite.recipient;
+}
+
+export function InviteTable({ onShowQr, refreshToken }: InviteTableProps) {
+  const [page, setPage] = useState(1);
+  const [status, setStatus] = useState<InviteStatus | "all">("all");
+  const [search, setSearch] = useState("");
+  const [query, setQuery] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<{ invites: Invite[]; total: number }>({ invites: [], total: 0 });
+
+  const totalPages = useMemo(() => {
+    if (data.total === 0) return 1;
+    return Math.max(1, Math.ceil(data.total / PAGE_SIZE));
+  }, [data.total]);
+
+  const fetchInvites = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await listInvites({
+        page,
+        pageSize: PAGE_SIZE,
+        status: status === "all" ? undefined : status,
+        search: query || undefined,
+      });
+      setData({ invites: result.invites, total: result.total });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to load invites.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [page, query, status]);
+
+  useEffect(() => {
+    void fetchInvites();
+  }, [fetchInvites, refreshToken]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [status, query, refreshToken]);
+
+  const handleSearch = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setQuery(search.trim());
+  };
+
+  const actions: InviteRowAction[] = useMemo(
+    () => [
+      {
+        label: "Copy link",
+        onAction: (invite) => {
+          if (navigator.clipboard && "writeText" in navigator.clipboard) {
+            void navigator.clipboard.writeText(invite.inviteUrl);
+          } else {
+            window.prompt("Invite link", invite.inviteUrl);
+          }
+        },
+      },
+      {
+        label: "Show QR",
+        onAction: (invite) => onShowQr(invite),
+      },
+      {
+        label: "Resend",
+        onAction: async (invite) => {
+          await resendInvite(invite.id);
+          await fetchInvites();
+        },
+        isDisabled: (invite) => invite.status === "revoked" || invite.status === "expired",
+      },
+      {
+        label: "Revoke",
+        onAction: async (invite) => {
+          if (invite.status === "revoked") return;
+          await updateInvite(invite.id, { status: "revoked" });
+          await fetchInvites();
+        },
+        isDisabled: (invite) => invite.status === "revoked",
+      },
+    ], [fetchInvites, onShowQr],
+  );
+
+  return (
+    <section className="ssg-card space-y-4" aria-labelledby="invite-table-heading">
+      <div className="space-y-1">
+        <h2 id="invite-table-heading" className="text-lg font-semibold">
+          Manage invites
+        </h2>
+        <p className="text-sm text-slate-500">Track invite status in real time and take quick actions.</p>
+      </div>
+
+      <form className="flex flex-wrap items-end gap-3" onSubmit={handleSearch}>
+        <label className="flex flex-col space-y-2" style={{ minWidth: "200px", maxWidth: "260px" }}>
+          <span className="text-sm font-medium text-slate-600">Status</span>
+          <select
+            className="ssg-input"
+            value={status}
+            onChange={(event) => setStatus(event.target.value as InviteStatus | "all")}
+          >
+            <option value="all">All statuses</option>
+            {Object.entries(STATUS_LABEL).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col space-y-2" style={{ flex: "1 1 220px", maxWidth: "320px" }}>
+          <span className="text-sm font-medium text-slate-600">Search</span>
+          <input
+            className="ssg-input"
+            placeholder="Email, phone, or code"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+          />
+        </label>
+
+        <button type="submit" className="ssg-btn" style={{ alignSelf: "flex-end" }}>
+          Search
+        </button>
+        <button
+          type="button"
+          className="ssg-btn"
+          style={{ alignSelf: "flex-end" }}
+          onClick={() => {
+            setSearch("");
+            setQuery("");
+          }}
+        >
+          Reset
+        </button>
+      </form>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-slate-200">
+          <thead className="text-left text-xs uppercase tracking-wide text-slate-500">
+            <tr>
+              <th className="py-2 pr-3">Recipient</th>
+              <th className="py-2 pr-3">Channel</th>
+              <th className="py-2 pr-3">Code</th>
+              <th className="py-2 pr-3">Status</th>
+              <th className="py-2 pr-3">Created</th>
+              <th className="py-2 pr-3">Expires</th>
+              <th className="py-2 pr-3">Clicked</th>
+              <th className="py-2 pr-3">Accepted</th>
+              <th className="py-2 pr-3">Registered</th>
+              <th className="py-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100 text-sm">
+            {isLoading ? (
+              <tr>
+                <td colSpan={10} className="py-6 text-center text-slate-500">
+                  Loading invites…
+                </td>
+              </tr>
+            ) : error ? (
+              <tr>
+                <td colSpan={10} className="py-6 text-center text-red-600">
+                  {error}
+                </td>
+              </tr>
+            ) : data.invites.length === 0 ? (
+              <tr>
+                <td colSpan={10} className="py-6 text-center text-slate-500">
+                  No invites found.
+                </td>
+              </tr>
+            ) : (
+              data.invites.map((invite) => {
+                const style = STATUS_STYLES[invite.status];
+                return (
+                  <tr key={invite.id} className="align-top">
+                    <td className="py-3 pr-3 font-medium text-slate-700">{formatRecipient(invite)}</td>
+                    <td className="py-3 pr-3 capitalize">{invite.channel}</td>
+                    <td className="py-3 pr-3 font-mono text-xs">{invite.code}</td>
+                    <td className="py-3 pr-3">
+                      <span
+                        className="inline-flex items-center rounded-full border px-2 py-1 text-xs font-semibold"
+                        style={style}
+                      >
+                        {STATUS_LABEL[invite.status]}
+                      </span>
+                    </td>
+                    <td className="py-3 pr-3 whitespace-nowrap">{formatDate(invite.createdAt)}</td>
+                    <td className="py-3 pr-3 whitespace-nowrap">{formatDate(invite.expiresAt)}</td>
+                    <td className="py-3 pr-3 whitespace-nowrap">{formatDate(invite.clickedAt)}</td>
+                    <td className="py-3 pr-3 whitespace-nowrap">{formatDate(invite.acceptedAt)}</td>
+                    <td className="py-3 pr-3 whitespace-nowrap">{formatDate(invite.registeredAt)}</td>
+                    <td className="py-3">
+                      <div className="flex flex-wrap gap-2">
+                        {actions.map((action) => (
+                          <button
+                            key={action.label}
+                            type="button"
+                            className="ssg-btn ssg-btn-sm"
+                            onClick={() => {
+                              if (action.isDisabled?.(invite)) return;
+                              void action.onAction(invite);
+                            }}
+                            disabled={action.isDisabled?.(invite)}
+                          >
+                            {action.label}
+                          </button>
+                        ))}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between border-t pt-4 text-sm text-slate-600">
+        <div>
+          {data.total === 0 ? (
+            <span>Showing 0 invites</span>
+          ) : (
+            <span>
+              Showing {(page - 1) * PAGE_SIZE + 1}–
+              {Math.min(page * PAGE_SIZE, data.total)} of {data.total} invites
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="ssg-btn"
+            onClick={() => setPage((current) => Math.max(1, current - 1))}
+            disabled={page === 1}
+          >
+            Previous
+          </button>
+          <span>
+            Page {page} of {totalPages}
+          </span>
+          <button
+            type="button"
+            className="ssg-btn"
+            onClick={() => setPage((current) => Math.min(totalPages, current + 1))}
+            disabled={page >= totalPages}
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/api/invites.ts
+++ b/src/lib/api/invites.ts
@@ -1,0 +1,56 @@
+import { api } from "../api";
+import type {
+  CreateInvitePayload,
+  Invite,
+  InvitePage,
+  InviteStatus,
+  UpdateInvitePayload,
+} from "@/types/invite";
+
+export interface ListInvitesParams {
+  page?: number;
+  pageSize?: number;
+  status?: InviteStatus | "all";
+  search?: string;
+}
+
+export async function createInvite(payload: CreateInvitePayload): Promise<Invite> {
+  return api<Invite>("/api/invites", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function listInvites(params: ListInvitesParams = {}): Promise<InvitePage> {
+  const searchParams = new URLSearchParams();
+  if (params.page) searchParams.set("page", String(params.page));
+  if (params.pageSize) searchParams.set("pageSize", String(params.pageSize));
+  if (params.status && params.status !== "all") searchParams.set("status", params.status);
+  if (params.search) searchParams.set("search", params.search.trim());
+  const query = searchParams.toString();
+  const path = query ? `/api/invites?${query}` : "/api/invites";
+  return api<InvitePage>(path);
+}
+
+export async function getInvite(inviteId: string): Promise<Invite> {
+  return api<Invite>(`/api/invites/${inviteId}`);
+}
+
+export async function resendInvite(inviteId: string): Promise<Invite> {
+  return api<Invite>(`/api/invites/${inviteId}/resend`, {
+    method: "POST",
+  });
+}
+
+export async function updateInvite(inviteId: string, payload: UpdateInvitePayload): Promise<Invite> {
+  return api<Invite>(`/api/invites/${inviteId}`, {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function acceptInvite(code: string): Promise<Invite> {
+  return api<Invite>(`/api/invites/${code}/accept`, {
+    method: "POST",
+  });
+}

--- a/src/types/invite.ts
+++ b/src/types/invite.ts
@@ -1,0 +1,41 @@
+export type InviteChannel = "email" | "sms" | "link";
+
+export type InviteStatus =
+  | "pending"
+  | "clicked"
+  | "accepted"
+  | "registered"
+  | "revoked"
+  | "expired";
+
+export interface Invite {
+  id: string;
+  code: string;
+  channel: InviteChannel;
+  recipient: string | null;
+  status: InviteStatus;
+  inviteUrl: string;
+  createdAt: string;
+  expiresAt: string | null;
+  clickedAt: string | null;
+  acceptedAt: string | null;
+  registeredAt: string | null;
+}
+
+export interface InvitePage {
+  invites: Invite[];
+  page: number;
+  pageSize: number;
+  total: number;
+}
+
+export interface CreateInvitePayload {
+  channel: InviteChannel;
+  recipient?: string;
+  expiresAt?: string | null;
+}
+
+export interface UpdateInvitePayload {
+  status?: InviteStatus;
+  expiresAt?: string | null;
+}


### PR DESCRIPTION
## Summary
- add an admin invites dashboard with guarded routing that composes the new invite form, table, and QR modal
- implement invite domain types and API client helpers for creating, listing, updating, and resending invites
- build a styled table with filtering, pagination, clipboard helpers, and QR-based sharing for invite links

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*
- npm test *(fails: vitest needs the jsdom dependency in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e9703a0224832e92341201e9af3e4d