### PR TITLE
Add token-aware auth provider and fetch helper

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -12,7 +12,6 @@ import { AuthField } from "@/components/forms/AuthField";
 import { Input } from "@/components/ui/Input";
 import { useAuth } from "@/context/AuthContext";
 import { apiClient } from "@/lib/apiClient";
-import { setAccessToken } from "@/lib/authClient";
 import { trackEvent } from "@/lib/analytics";
 import type { User } from "@/types/user";
 
@@ -30,7 +29,7 @@ type SummaryItem = {
 
 export default function LoginPage() {
   const router = useRouter();
-  const { setUser, refreshUser } = useAuth();
+  const { login } = useAuth();
   const [formError, setFormError] = useState<string | null>(null);
   const [showPassword, setShowPassword] = useState(false);
   const [focusSummary, setFocusSummary] = useState(false);
@@ -90,21 +89,17 @@ export default function LoginPage() {
           skipAuth: true,
         });
 
-        if (response?.accessToken) {
-          setAccessToken(response.accessToken);
-        }
-
-        const account = response?.user ?? (await refreshUser());
-        if (account) {
-          setUser(account);
-        }
+        const account = await login({
+          accessToken: response?.accessToken ?? null,
+          user: response?.user,
+        });
 
         trackEvent("login_success", {
           email: (response?.user ?? account)?.email ?? values.email,
         });
 
         router.replace("/");
-      } catch (error) {
+      } catch {
         setFormError("We couldn’t sign you in with those credentials. Please try again.");
         setFocusSummary(true);
       }

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -13,7 +13,6 @@ import { PasswordStrength } from "@/components/forms/PasswordStrength";
 import { Input } from "@/components/ui/Input";
 import { useAuth } from "@/context/AuthContext";
 import { apiClient, ApiError } from "@/lib/apiClient";
-import { setAccessToken } from "@/lib/authClient";
 import { trackEvent } from "@/lib/analytics";
 import type { User } from "@/types/user";
 
@@ -38,7 +37,7 @@ type SummaryItem = {
 
 export default function RegisterPage() {
   const router = useRouter();
-  const { setUser, refreshUser } = useAuth();
+  const { login } = useAuth();
   const [formError, setFormError] = useState<string | null>(null);
   const [showPassword, setShowPassword] = useState(false);
   const [focusSummary, setFocusSummary] = useState(false);
@@ -104,14 +103,10 @@ export default function RegisterPage() {
           skipAuth: true,
         });
 
-        if (response?.accessToken) {
-          setAccessToken(response.accessToken);
-        }
-
-        const account = response?.user ?? (await refreshUser());
-        if (account) {
-          setUser(account);
-        }
+        const account = await login({
+          accessToken: response?.accessToken ?? null,
+          user: response?.user,
+        });
 
         trackEvent("register_completed", {
           email: (response?.user ?? account)?.email ?? values.email,

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,10 +7,12 @@ import Logo from "./Logo";
 import NavLink from "./NavLink";
 import styles from "./Navbar.module.css";
 import { useAuth } from "@/context/AuthContext";
+import { feature } from "@/lib/features";
 import { getInitials } from "@/lib/ui";
 
 export default function Navbar() {
   const { user, logout } = useAuth();
+  const isAuthEnabled = feature.auth;
   const router = useRouter();
   const [mobileOpen, setMobileOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -101,6 +103,10 @@ export default function Navbar() {
   const navItems = useMemo(() => {
     const items = [{ href: "/", label: "Home" }];
 
+    if (!isAuthEnabled) {
+      return items;
+    }
+
     if (user?.role === "admin") {
       items.push({ href: "/admin", label: "Admin" });
     }
@@ -113,7 +119,7 @@ export default function Navbar() {
     }
 
     return items;
-  }, [user]);
+  }, [isAuthEnabled, user]);
 
   const avatar = useMemo(() => {
     if (!user) return null;
@@ -171,68 +177,70 @@ export default function Navbar() {
         </nav>
 
         <div className={styles.actions}>
-          {user ? (
-            <>
-              <button
-                type="button"
-                className={styles.avatarButton}
-                aria-haspopup="menu"
-                aria-expanded={menuOpen}
-                aria-controls="user-menu"
-                onClick={() => setMenuOpen((open) => !open)}
-                ref={menuButtonRef}
-              >
-                <span className={styles.avatar} aria-hidden="true">
-                  {avatar}
-                </span>
-                <span className={styles.srOnly}>Open account menu</span>
-              </button>
-              <div
-                id="user-menu"
-                className={`${styles.menu} ${menuOpen ? styles.menuOpen : ""}`}
-                role="menu"
-                ref={menuRef}
-              >
-                <div className={styles.menuHeader}>
-                  <div className={styles.menuName}>{user.name}</div>
-                  <div className={styles.menuEmail}>{user.email}</div>
-                  {user.role ? <span className={styles.roleTag}>{user.role}</span> : null}
+          {isAuthEnabled ? (
+            user ? (
+              <>
+                <button
+                  type="button"
+                  className={styles.avatarButton}
+                  aria-haspopup="menu"
+                  aria-expanded={menuOpen}
+                  aria-controls="user-menu"
+                  onClick={() => setMenuOpen((open) => !open)}
+                  ref={menuButtonRef}
+                >
+                  <span className={styles.avatar} aria-hidden="true">
+                    {avatar}
+                  </span>
+                  <span className={styles.srOnly}>Open account menu</span>
+                </button>
+                <div
+                  id="user-menu"
+                  className={`${styles.menu} ${menuOpen ? styles.menuOpen : ""}`}
+                  role="menu"
+                  ref={menuRef}
+                >
+                  <div className={styles.menuHeader}>
+                    <div className={styles.menuName}>{user.name}</div>
+                    <div className={styles.menuEmail}>{user.email}</div>
+                    {user.role ? <span className={styles.roleTag}>{user.role}</span> : null}
+                  </div>
+                  <div className={styles.menuList}>
+                    <Link
+                      href="/me"
+                      className={`${styles.menuItem} ${styles.menuLink}`}
+                      role="menuitem"
+                      tabIndex={menuOpen ? 0 : -1}
+                      onClick={() => {
+                        closeMenu();
+                        closeMobile();
+                      }}
+                    >
+                      Profile
+                    </Link>
+                    <div className={styles.menuDivider} aria-hidden="true" />
+                    <button
+                      type="button"
+                      className={styles.menuItem}
+                      role="menuitem"
+                      onClick={handleLogout}
+                    >
+                      Logout
+                    </button>
+                  </div>
                 </div>
-                <div className={styles.menuList}>
-                  <Link
-                    href="/me"
-                    className={`${styles.menuItem} ${styles.menuLink}`}
-                    role="menuitem"
-                    tabIndex={menuOpen ? 0 : -1}
-                    onClick={() => {
-                      closeMenu();
-                      closeMobile();
-                    }}
-                  >
-                    Profile
-                  </Link>
-                  <div className={styles.menuDivider} aria-hidden="true" />
-                  <button
-                    type="button"
-                    className={styles.menuItem}
-                    role="menuitem"
-                    onClick={handleLogout}
-                  >
-                    Logout
-                  </button>
-                </div>
+              </>
+            ) : (
+              <div className={styles.authLinks}>
+                <Link href="/login" className={styles.authButton} onClick={closeMobile}>
+                  Log In
+                </Link>
+                <Link href="/register" className={styles.authButton} onClick={closeMobile}>
+                  Register
+                </Link>
               </div>
-            </>
-          ) : (
-            <div className={styles.authLinks}>
-              <Link href="/login" className={styles.authButton} onClick={closeMobile}>
-                Log In
-              </Link>
-              <Link href="/register" className={styles.authButton} onClick={closeMobile}>
-                Register
-              </Link>
-            </div>
-          )}
+            )
+          ) : null}
         </div>
       </div>
     </header>

--- a/src/lib/authClient.ts
+++ b/src/lib/authClient.ts
@@ -4,11 +4,21 @@ type RefreshOptions = {
   signal?: AbortSignal;
 };
 
+type AccessTokenListener = (token: string | null) => void;
+
 let accessToken: string | null = null;
 let refreshPromise: Promise<string | null> | null = null;
+const accessTokenListeners = new Set<AccessTokenListener>();
+
+function notifyAccessTokenChange() {
+  for (const listener of accessTokenListeners) {
+    listener(accessToken);
+  }
+}
 
 export function setAccessToken(token: string | null) {
   accessToken = token ?? null;
+  notifyAccessTokenChange();
 }
 
 export function getAccessToken() {
@@ -17,6 +27,14 @@ export function getAccessToken() {
 
 export function clearAccessToken() {
   accessToken = null;
+  notifyAccessTokenChange();
+}
+
+export function subscribeToAccessToken(listener: AccessTokenListener) {
+  accessTokenListeners.add(listener);
+  return () => {
+    accessTokenListeners.delete(listener);
+  };
 }
 
 export async function ensureAccessToken(options: RefreshOptions = {}) {

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -1,0 +1,3 @@
+export const feature = {
+  auth: process.env.NEXT_PUBLIC_FEATURE_AUTH !== "false",
+};

--- a/src/lib/fetchWithAuth.ts
+++ b/src/lib/fetchWithAuth.ts
@@ -1,0 +1,50 @@
+import { clearAccessToken, getAccessToken, refreshAccessToken } from "./authClient";
+
+type FetchWithAuthOptions = {
+  skipAuth?: boolean;
+  onUnauthorized?: () => void;
+};
+
+function defaultOnUnauthorized() {
+  if (typeof window !== "undefined") {
+    window.location.replace("/login");
+  }
+}
+
+export async function fetchWithAuth(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+  options: FetchWithAuthOptions = {},
+) {
+  const { skipAuth = false, onUnauthorized } = options;
+  const headers = new Headers(init.headers ?? (input instanceof Request ? input.headers : undefined));
+
+  if (!skipAuth) {
+    const token = getAccessToken();
+    if (token && !headers.has("Authorization")) {
+      headers.set("Authorization", `Bearer ${token}`);
+    }
+  }
+
+  const requestInit: RequestInit = {
+    ...init,
+    headers,
+  };
+
+  const execute = () => fetch(input, requestInit);
+  let response = await execute();
+
+  if (response.status === 401 && !skipAuth) {
+    const refreshed = await refreshAccessToken().catch(() => null);
+
+    if (refreshed) {
+      headers.set("Authorization", `Bearer ${refreshed}`);
+      response = await execute();
+    } else {
+      clearAccessToken();
+      (onUnauthorized ?? defaultOnUnauthorized)();
+    }
+  }
+
+  return response;
+}


### PR DESCRIPTION
## Summary
- extend the auth provider to track the active access token, expose login/logout helpers, and redirect to /login when silent refresh fails while respecting the `feature.auth` flag
- add a reusable `fetchWithAuth` utility that injects bearer tokens, retries once after a refresh request, and plug it into the shared API client
- update login/register screens and the navbar to consume the new auth helpers and feature gating logic

## Testing
- `npm run lint` *(fails: legacy lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ed420e4e34832eaeace91cc733cf81